### PR TITLE
Add missing XML summaries

### DIFF
--- a/src/DataSources/CSharp/CSharpChunker.cs
+++ b/src/DataSources/CSharp/CSharpChunker.cs
@@ -7,10 +7,10 @@ using SimpleRag.DataSources.CSharp.Models;
 
 namespace SimpleRag.DataSources.CSharp
 {
-    [UsedImplicitly]
     /// <summary>
     /// Breaks C# code into smaller chunks for ingestion.
     /// </summary>
+    [PublicAPI]
     public class CSharpChunker
     {
         /// <summary>
@@ -120,7 +120,6 @@ namespace SimpleRag.DataSources.CSharp
                 FieldDeclarationSyntax[] constants = GetPublicConstants(node.Members);
                 ConversionOperatorDeclarationSyntax[] implicitOperators = GetPublicImplicitOperators(node.Members);
                 ConstructorDeclarationSyntax[] constructors = GetPublicConstructors(node.Members);
-                //todo - Support more types (https://github.com/rwjdk/CodeRag/issues/1)
 
                 string ns = GetNamespace(node);
 

--- a/src/DataSources/CSharp/CSharpChunker.cs
+++ b/src/DataSources/CSharp/CSharpChunker.cs
@@ -8,8 +8,16 @@ using SimpleRag.DataSources.CSharp.Models;
 namespace SimpleRag.DataSources.CSharp
 {
     [UsedImplicitly]
+    /// <summary>
+    /// Breaks C# code into smaller chunks for ingestion.
+    /// </summary>
     public class CSharpChunker
     {
+        /// <summary>
+        /// Parses the provided code and returns the discovered code entities.
+        /// </summary>
+        /// <param name="code">The code to analyze.</param>
+        /// <returns>A list of discovered code chunks.</returns>
         public List<CSharpChunk> GetCodeEntities(string code)
         {
             SyntaxTree tree = CSharpSyntaxTree.ParseText(code);

--- a/src/DataSources/CSharp/CSharpDataSourceCommand.cs
+++ b/src/DataSources/CSharp/CSharpDataSourceCommand.cs
@@ -19,7 +19,7 @@ namespace SimpleRag.DataSources.CSharp;
 /// <param name="vectorStoreQuery">The query service for retrieving existing vector entities from the vector store.</param>
 /// <param name="gitHubFilesQuery">The query service for retrieving C# files from GitHub sources.</param>
 /// <param name="localFilesQuery">The query service for retrieving C# files from local sources.</param>
-[UsedImplicitly]
+[PublicAPI]
 public class CSharpDataSourceCommand(
     CSharpChunker chunker,
     VectorStoreCommand vectorStoreCommand,

--- a/src/DataSources/CSharp/Models/CSharpChunk.cs
+++ b/src/DataSources/CSharp/Models/CSharpChunk.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using JetBrains.Annotations;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Formatting;
 
@@ -16,6 +17,7 @@ namespace SimpleRag.DataSources.CSharp.Models;
 /// <param name="value">The string representation of the code element.</param>
 /// <param name="dependencies">A list of dependencies for the code element.</param>
 /// <param name="node">The syntax node from Roslyn.</param>
+[PublicAPI]
 public class CSharpChunk(CSharpKind kind, string @namespace, string? parent, CSharpKind? parentKind, string name, string xmlSummary, string value, List<string> dependencies, SyntaxNode node)
 {
     /// <summary>

--- a/src/DataSources/CSharp/Models/CSharpDataSourceGitHub.cs
+++ b/src/DataSources/CSharp/Models/CSharpDataSourceGitHub.cs
@@ -11,17 +11,17 @@ public class CSharpDataSourceGitHub : DataSource
     /// <summary>
     /// Gets or sets the owner of the repository on GitHub.
     /// </summary>
-    public required string GitHubOwner { get; set; }
+    public required string GitHubOwner { get; init; }
 
     /// <summary>
     /// Gets or sets the name of the repository on GitHub.
     /// </summary>
-    public required string GitHubRepo { get; set; }
+    public required string GitHubRepo { get; init; }
 
     /// <summary>
     /// Gets or sets the timestamp of the last commit to check for changes.
     /// </summary>
-    public DateTimeOffset? GitHubLastCommitTimestamp { get; set; }
+    public DateTimeOffset? GitHubLastCommitTimestamp { get; init; }
 
     /// <summary>
     /// Converts this object to a <see cref="FileContentSourceGitHub"/> object.

--- a/src/DataSources/CSharp/Models/CSharpDataSourceLocal.cs
+++ b/src/DataSources/CSharp/Models/CSharpDataSourceLocal.cs
@@ -3,8 +3,15 @@ using SimpleRag.FileContent.Models;
 
 namespace SimpleRag.DataSources.CSharp.Models;
 
+/// <summary>
+/// Represents a local C# data source on disk.
+/// </summary>
 public class CSharpDataSourceLocal : DataSource
 {
+    /// <summary>
+    /// Converts this instance to a <see cref="FileContentSourceLocal"/>.
+    /// </summary>
+    /// <returns>The created file content source.</returns>
     public FileContentSourceLocal AsFileContentSource()
     {
         return new FileContentSourceLocal

--- a/src/DataSources/CSharp/Models/CSharpKind.cs
+++ b/src/DataSources/CSharp/Models/CSharpKind.cs
@@ -1,14 +1,34 @@
 namespace SimpleRag.DataSources.CSharp.Models;
 
+/// <summary>
+/// Represents the kind of C# code element.
+/// </summary>
 public enum CSharpKind
 {
+    /// <summary>No specific kind.</summary>
     None,
+
+    /// <summary>An interface declaration.</summary>
     Interface,
+
+    /// <summary>A delegate declaration.</summary>
     Delegate,
+
+    /// <summary>An enum declaration.</summary>
     Enum,
+
+    /// <summary>A method declaration.</summary>
     Method,
+
+    /// <summary>A class declaration.</summary>
     Class,
+
+    /// <summary>A struct declaration.</summary>
     Struct,
+
+    /// <summary>A record declaration.</summary>
     Record,
+
+    /// <summary>A constructor declaration.</summary>
     Constructor
 }

--- a/src/DataSources/Markdown/MarkdownChunker.cs
+++ b/src/DataSources/Markdown/MarkdownChunker.cs
@@ -4,10 +4,10 @@ using SimpleRag.DataSources.Markdown.Models;
 
 namespace SimpleRag.DataSources.Markdown
 {
-    [UsedImplicitly]
     /// <summary>
     /// Splits markdown content into smaller chunks.
     /// </summary>
+    [PublicAPI]
     public class MarkdownChunker
     {
         /// <summary>

--- a/src/DataSources/Markdown/MarkdownChunker.cs
+++ b/src/DataSources/Markdown/MarkdownChunker.cs
@@ -5,8 +5,19 @@ using SimpleRag.DataSources.Markdown.Models;
 namespace SimpleRag.DataSources.Markdown
 {
     [UsedImplicitly]
+    /// <summary>
+    /// Splits markdown content into smaller chunks.
+    /// </summary>
     public class MarkdownChunker
     {
+        /// <summary>
+        /// Breaks the specified markdown content into chunks.
+        /// </summary>
+        /// <param name="content">The markdown content.</param>
+        /// <param name="level">The heading level to chunk at.</param>
+        /// <param name="linesToIgnorePatterns">Optional patterns of lines to ignore.</param>
+        /// <param name="ignoreIfLessThanThisAmountOfChars">Optional minimum size for a chunk.</param>
+        /// <returns>The created chunks.</returns>
         public MarkdownChunk[] GetChunks(string content, int level = 3, string? linesToIgnorePatterns = null, int? ignoreIfLessThanThisAmountOfChars = null)
         {
             List<MarkdownChunk> chunks = [];

--- a/src/DataSources/Markdown/MarkdownDataSourceCommand.cs
+++ b/src/DataSources/Markdown/MarkdownDataSourceCommand.cs
@@ -11,6 +11,9 @@ using SimpleRag.Models;
 namespace SimpleRag.DataSources.Markdown;
 
 [UsedImplicitly]
+/// <summary>
+/// Command used for ingesting markdown based data sources.
+/// </summary>
 public class MarkdownDataSourceCommand(
     MarkdownChunker chunker,
     VectorStoreQuery vectorStoreQuery,
@@ -18,8 +21,14 @@ public class MarkdownDataSourceCommand(
     FileContentGitHubQuery gitHubFileContentQuery,
     FileContentLocalQuery localFileContentQuery) : ProgressNotificationBase
 {
+    /// <summary>The source kind handled by this command.</summary>
     public const string SourceKind = "Markdown";
 
+    /// <summary>
+    /// Ingests a local markdown source.
+    /// </summary>
+    /// <param name="dataSource">The source to ingest.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public async Task IngestAsync(MarkdownDataSourceLocal dataSource, CancellationToken cancellationToken = default)
     {
         Guards(dataSource);
@@ -36,6 +45,11 @@ public class MarkdownDataSourceCommand(
         await IngestAsync(dataSource, rawFiles, cancellationToken);
     }
 
+    /// <summary>
+    /// Ingests a GitHub based markdown source.
+    /// </summary>
+    /// <param name="dataSource">The source to ingest.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public async Task IngestAsync(MarkdownDataSourceGitHub dataSource, CancellationToken cancellationToken = default)
     {
         Guards(dataSource);

--- a/src/DataSources/Markdown/MarkdownDataSourceCommand.cs
+++ b/src/DataSources/Markdown/MarkdownDataSourceCommand.cs
@@ -10,10 +10,10 @@ using SimpleRag.Models;
 
 namespace SimpleRag.DataSources.Markdown;
 
-[UsedImplicitly]
 /// <summary>
 /// Command used for ingesting markdown based data sources.
 /// </summary>
+[PublicAPI]
 public class MarkdownDataSourceCommand(
     MarkdownChunker chunker,
     VectorStoreQuery vectorStoreQuery,

--- a/src/DataSources/Markdown/Models/MarkdownChunk.cs
+++ b/src/DataSources/Markdown/Models/MarkdownChunk.cs
@@ -1,4 +1,9 @@
-﻿namespace SimpleRag.DataSources.Markdown.Models
-{
-    public record MarkdownChunk(string ChunkId, string Name, string Content);
-}
+namespace SimpleRag.DataSources.Markdown.Models;
+
+/// <summary>
+/// Represents a chunk of markdown content.
+/// </summary>
+/// <param name="ChunkId">Identifier of the chunk.</param>
+/// <param name="Name">The display name of the chunk.</param>
+/// <param name="Content">The chunk content.</param>
+public record MarkdownChunk(string ChunkId, string Name, string Content);

--- a/src/DataSources/Markdown/Models/MarkdownDataSourceGitHub.cs
+++ b/src/DataSources/Markdown/Models/MarkdownDataSourceGitHub.cs
@@ -8,13 +8,13 @@ namespace SimpleRag.DataSources.Markdown.Models;
 public class MarkdownDataSourceGitHub : MarkdownSource
 {
     /// <summary>Gets or sets the GitHub repository owner.</summary>
-    public required string GitHubOwner { get; set; }
+    public required string GitHubOwner { get; init; }
 
     /// <summary>Gets or sets the GitHub repository name.</summary>
-    public required string GitHubRepo { get; set; }
+    public required string GitHubRepo { get; init; }
 
     /// <summary>Gets or sets the last commit timestamp processed.</summary>
-    public DateTimeOffset? GitHubLastCommitTimestamp { get; set; }
+    public DateTimeOffset? GitHubLastCommitTimestamp { get; init; }
 
     /// <summary>
     /// Converts this instance to a <see cref="FileContentSourceGitHub"/>.

--- a/src/DataSources/Markdown/Models/MarkdownDataSourceGitHub.cs
+++ b/src/DataSources/Markdown/Models/MarkdownDataSourceGitHub.cs
@@ -2,12 +2,24 @@
 
 namespace SimpleRag.DataSources.Markdown.Models;
 
+/// <summary>
+/// Represents a markdown source retrieved from GitHub.
+/// </summary>
 public class MarkdownDataSourceGitHub : MarkdownSource
 {
+    /// <summary>Gets or sets the GitHub repository owner.</summary>
     public required string GitHubOwner { get; set; }
+
+    /// <summary>Gets or sets the GitHub repository name.</summary>
     public required string GitHubRepo { get; set; }
+
+    /// <summary>Gets or sets the last commit timestamp processed.</summary>
     public DateTimeOffset? GitHubLastCommitTimestamp { get; set; }
 
+    /// <summary>
+    /// Converts this instance to a <see cref="FileContentSourceGitHub"/>.
+    /// </summary>
+    /// <returns>The created file content source.</returns>
     public FileContentSourceGitHub AsFileContentSource()
     {
         return new FileContentSourceGitHub

--- a/src/DataSources/Markdown/Models/MarkdownDataSourceLocal.cs
+++ b/src/DataSources/Markdown/Models/MarkdownDataSourceLocal.cs
@@ -2,8 +2,15 @@
 
 namespace SimpleRag.DataSources.Markdown.Models;
 
+/// <summary>
+/// Represents a markdown source located on the local file system.
+/// </summary>
 public class MarkdownDataSourceLocal : MarkdownSource
 {
+    /// <summary>
+    /// Converts this instance to a <see cref="FileContentSourceLocal"/>.
+    /// </summary>
+    /// <returns>The created file content source.</returns>
     public FileContentSourceLocal AsFileContentSource()
     {
         return new FileContentSourceLocal

--- a/src/DataSources/Markdown/Models/MarkdownSource.cs
+++ b/src/DataSources/Markdown/Models/MarkdownSource.cs
@@ -2,12 +2,26 @@
 
 namespace SimpleRag.DataSources.Markdown.Models;
 
+/// <summary>
+/// Base class for markdown sources.
+/// </summary>
 public abstract class MarkdownSource : DataSource
 {
+    /// <summary>Gets or sets a value indicating whether HTML comments should be ignored.</summary>
     public bool IgnoreCommentedOutContent { get; set; } = true;
+
+    /// <summary>Gets or sets a value indicating whether image references should be ignored.</summary>
     public bool IgnoreImages { get; set; } = true;
+
+    /// <summary>Gets or sets the line count threshold for chunking files.</summary>
     public int? OnlyChunkIfMoreThanThisNumberOfLines { get; set; } = 25;
+
+    /// <summary>Gets or sets the heading levels to chunk at.</summary>
     public int LevelsToChunk { get; set; } = 2;
+
+    /// <summary>Gets or sets patterns for lines to ignore when chunking.</summary>
     public string? ChunkLineIgnorePatterns { get; set; }
+
+    /// <summary>Gets or sets the minimum size of a chunk in characters.</summary>
     public int? IgnoreChunkIfLessThanThisAmountOfChars { get; set; } = 25;
 }

--- a/src/DataSources/Markdown/Models/MarkdownSource.cs
+++ b/src/DataSources/Markdown/Models/MarkdownSource.cs
@@ -8,20 +8,20 @@ namespace SimpleRag.DataSources.Markdown.Models;
 public abstract class MarkdownSource : DataSource
 {
     /// <summary>Gets or sets a value indicating whether HTML comments should be ignored.</summary>
-    public bool IgnoreCommentedOutContent { get; set; } = true;
+    public bool IgnoreCommentedOutContent { get; init; } = true;
 
     /// <summary>Gets or sets a value indicating whether image references should be ignored.</summary>
-    public bool IgnoreImages { get; set; } = true;
+    public bool IgnoreImages { get; init; } = true;
 
     /// <summary>Gets or sets the line count threshold for chunking files.</summary>
-    public int? OnlyChunkIfMoreThanThisNumberOfLines { get; set; } = 25;
+    public int? OnlyChunkIfMoreThanThisNumberOfLines { get; init; } = 25;
 
     /// <summary>Gets or sets the heading levels to chunk at.</summary>
-    public int LevelsToChunk { get; set; } = 2;
+    public int LevelsToChunk { get; init; } = 2;
 
     /// <summary>Gets or sets patterns for lines to ignore when chunking.</summary>
-    public string? ChunkLineIgnorePatterns { get; set; }
+    public string? ChunkLineIgnorePatterns { get; init; }
 
     /// <summary>Gets or sets the minimum size of a chunk in characters.</summary>
-    public int? IgnoreChunkIfLessThanThisAmountOfChars { get; set; } = 25;
+    public int? IgnoreChunkIfLessThanThisAmountOfChars { get; init; } = 25;
 }

--- a/src/DataSources/Models/DataSource.cs
+++ b/src/DataSources/Models/DataSource.cs
@@ -1,11 +1,25 @@
-﻿namespace SimpleRag.DataSources.Models;
+namespace SimpleRag.DataSources.Models;
 
+/// <summary>
+/// Base class for all ingestible data sources.
+/// </summary>
 public abstract class DataSource
 {
+    /// <summary>Gets or sets the identifier of the collection.</summary>
     public required string CollectionId { get; set; }
+
+    /// <summary>Gets or sets the unique identifier of the source.</summary>
     public required string Id { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether subdirectories are scanned.</summary>
     public bool Recursive { get; set; } = true;
+
+    /// <summary>Gets or sets the root path of the source.</summary>
     public required string Path { get; set; }
+
+    /// <summary>Gets or sets patterns for files to ignore.</summary>
     public string? FileIgnorePatterns { get; set; }
+
+    /// <summary>Gets or sets the threshold for ignoring large files.</summary>
     public int? IgnoreFileIfMoreThanThisNumberOfLines { get; set; }
 }

--- a/src/DataSources/Models/DataSource.cs
+++ b/src/DataSources/Models/DataSource.cs
@@ -6,20 +6,20 @@ namespace SimpleRag.DataSources.Models;
 public abstract class DataSource
 {
     /// <summary>Gets or sets the identifier of the collection.</summary>
-    public required string CollectionId { get; set; }
+    public required string CollectionId { get; init; }
 
     /// <summary>Gets or sets the unique identifier of the source.</summary>
-    public required string Id { get; set; }
+    public required string Id { get; init; }
 
     /// <summary>Gets or sets a value indicating whether subdirectories are scanned.</summary>
-    public bool Recursive { get; set; } = true;
+    public bool Recursive { get; init; } = true;
 
     /// <summary>Gets or sets the root path of the source.</summary>
-    public required string Path { get; set; }
+    public required string Path { get; init; }
 
     /// <summary>Gets or sets patterns for files to ignore.</summary>
-    public string? FileIgnorePatterns { get; set; }
+    public string? FileIgnorePatterns { get; init; }
 
     /// <summary>Gets or sets the threshold for ignoring large files.</summary>
-    public int? IgnoreFileIfMoreThanThisNumberOfLines { get; set; }
+    public int? IgnoreFileIfMoreThanThisNumberOfLines { get; init; }
 }

--- a/src/DataSources/Models/DataSourceException.cs
+++ b/src/DataSources/Models/DataSourceException.cs
@@ -1,3 +1,6 @@
-﻿namespace SimpleRag.DataSources.Models;
+namespace SimpleRag.DataSources.Models;
 
+/// <summary>
+/// Exception thrown when a data source is misconfigured.
+/// </summary>
 public class SourceException(string message, Exception? innerException = null) : Exception(message, innerException);

--- a/src/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Extensions/ServiceCollectionExtensions.cs
@@ -7,9 +7,15 @@ using SimpleRag.VectorStorage;
 
 namespace SimpleRag.Extensions;
 
+/// <summary>
+/// Extension methods for registering SimpleRag services.
+/// </summary>
 public static class ServiceCollectionExtensions
 {
     //todo - add option for keyed services
+    /// <summary>
+    /// Registers SimpleRag services without GitHub integration.
+    /// </summary>
     public static void AddSimpleRag<T>(
         this IServiceCollection services,
         VectorStoreConfiguration configuration,
@@ -18,6 +24,9 @@ public static class ServiceCollectionExtensions
         services.AddSimpleRagWithGitHubIntegration(configuration, vectorStoreFactory, string.Empty);
     }
 
+    /// <summary>
+    /// Registers SimpleRag services including GitHub integration.
+    /// </summary>
     public static void AddSimpleRagWithGitHubIntegration<T>(
         this IServiceCollection services,
         VectorStoreConfiguration configuration,

--- a/src/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
 using SimpleRag.DataSources.CSharp;
 using SimpleRag.DataSources.Markdown;
 using SimpleRag.FileContent;
@@ -12,10 +13,10 @@ namespace SimpleRag.Extensions;
 /// </summary>
 public static class ServiceCollectionExtensions
 {
-    //todo - add option for keyed services
     /// <summary>
     /// Registers SimpleRag services without GitHub integration.
     /// </summary>
+    [PublicAPI]
     public static void AddSimpleRag<T>(
         this IServiceCollection services,
         VectorStoreConfiguration configuration,
@@ -27,6 +28,7 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Registers SimpleRag services including GitHub integration.
     /// </summary>
+    [PublicAPI]
     public static void AddSimpleRagWithGitHubIntegration<T>(
         this IServiceCollection services,
         VectorStoreConfiguration configuration,

--- a/src/FileContent/FileContentException.cs
+++ b/src/FileContent/FileContentException.cs
@@ -1,3 +1,6 @@
-﻿namespace SimpleRag.FileContent;
+namespace SimpleRag.FileContent;
 
+/// <summary>
+/// Exception thrown when file content retrieval fails.
+/// </summary>
 public class FileContentException(string message, Exception? innerException = null) : Exception(message, innerException);

--- a/src/FileContent/FileContentGitHubQuery.cs
+++ b/src/FileContent/FileContentGitHubQuery.cs
@@ -5,10 +5,10 @@ using SimpleRag.Integrations.GitHub;
 
 namespace SimpleRag.FileContent;
 
-[UsedImplicitly]
 /// <summary>
 /// Retrieves file content from GitHub sources.
 /// </summary>
+[PublicAPI]
 public class FileContentGitHubQuery(GitHubQuery gitHubQuery) : FileContentQuery
 {
     /// <summary>

--- a/src/FileContent/FileContentGitHubQuery.cs
+++ b/src/FileContent/FileContentGitHubQuery.cs
@@ -6,8 +6,14 @@ using SimpleRag.Integrations.GitHub;
 namespace SimpleRag.FileContent;
 
 [UsedImplicitly]
+/// <summary>
+/// Retrieves file content from GitHub sources.
+/// </summary>
 public class FileContentGitHubQuery(GitHubQuery gitHubQuery) : FileContentQuery
 {
+    /// <summary>
+    /// Gets the raw content for a GitHub source.
+    /// </summary>
     public async Task<Models.FileContent[]?> GetRawContentForSourceAsync(FileContentSourceGitHub source, string fileExtensionType, CancellationToken cancellationToken = default)
     {
         SharedGuards(source);

--- a/src/FileContent/FileContentLocalQuery.cs
+++ b/src/FileContent/FileContentLocalQuery.cs
@@ -4,10 +4,10 @@ using SimpleRag.FileContent.Models;
 
 namespace SimpleRag.FileContent;
 
-[UsedImplicitly]
 /// <summary>
 /// Retrieves file content from the local file system.
 /// </summary>
+[PublicAPI]
 public class FileContentLocalQuery : FileContentQuery
 {
     internal async Task<Models.FileContent[]?> GetRawContentForSourceAsync(FileContentSourceLocal source, string fileExtensionType, CancellationToken cancellationToken = default)
@@ -32,7 +32,7 @@ public class FileContentLocalQuery : FileContentQuery
             counter++;
             OnNotifyProgress("Parsing Local files from Disk", counter, files.Length);
             var pathWithoutRoot = path.Replace(source.Path, string.Empty);
-            string content = await System.IO.File.ReadAllTextAsync(path, Encoding.UTF8, cancellationToken);
+            string content = await File.ReadAllTextAsync(path, Encoding.UTF8, cancellationToken);
             result.Add(new Models.FileContent(path, content, pathWithoutRoot));
         }
 

--- a/src/FileContent/FileContentLocalQuery.cs
+++ b/src/FileContent/FileContentLocalQuery.cs
@@ -5,6 +5,9 @@ using SimpleRag.FileContent.Models;
 namespace SimpleRag.FileContent;
 
 [UsedImplicitly]
+/// <summary>
+/// Retrieves file content from the local file system.
+/// </summary>
 public class FileContentLocalQuery : FileContentQuery
 {
     internal async Task<Models.FileContent[]?> GetRawContentForSourceAsync(FileContentSourceLocal source, string fileExtensionType, CancellationToken cancellationToken = default)

--- a/src/FileContent/FileContentQuery.cs
+++ b/src/FileContent/FileContentQuery.cs
@@ -4,6 +4,9 @@ using SimpleRag.Models;
 
 namespace SimpleRag.FileContent;
 
+/// <summary>
+/// Base class for querying file content sources.
+/// </summary>
 public abstract class FileContentQuery : ProgressNotificationBase
 {
     protected void SharedGuards(FileContentSource source)
@@ -27,6 +30,9 @@ public abstract class FileContentQuery : ProgressNotificationBase
         }
     }
 
+    /// <summary>
+    /// Determines whether the specified path should be ignored based on patterns.
+    /// </summary>
     public bool IgnoreFile(string path, string fileIgnorePatterns)
     {
         if (string.IsNullOrWhiteSpace(fileIgnorePatterns))

--- a/src/FileContent/FileContentQuery.cs
+++ b/src/FileContent/FileContentQuery.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using JetBrains.Annotations;
 using SimpleRag.FileContent.Models;
 using SimpleRag.Models;
 
@@ -7,8 +8,14 @@ namespace SimpleRag.FileContent;
 /// <summary>
 /// Base class for querying file content sources.
 /// </summary>
+[PublicAPI]
 public abstract class FileContentQuery : ProgressNotificationBase
 {
+    /// <summary>
+    /// Guards for input
+    /// </summary>
+    /// <param name="source"></param>
+    /// <exception cref="FileContentException"></exception>
     protected void SharedGuards(FileContentSource source)
     {
         if (string.IsNullOrWhiteSpace(source.Path))
@@ -17,11 +24,19 @@ public abstract class FileContentQuery : ProgressNotificationBase
         }
     }
 
-    protected void NotifyNumberOfFilesFound(int length)
+    /// <summary>
+    /// Notify how many Number of files found
+    /// </summary>
+    /// <param name="numberOfFiles">Number of files</param>
+    protected void NotifyNumberOfFilesFound(int numberOfFiles)
     {
-        OnNotifyProgress($"Found {length} files");
+        OnNotifyProgress($"Found {numberOfFiles} files");
     }
 
+    /// <summary>
+    /// Notify of what files where ignored
+    /// </summary>
+    /// <param name="ignoredFiles"></param>
     protected void NotifyIgnoredFiles(List<string> ignoredFiles)
     {
         if (ignoredFiles.Count > 0)

--- a/src/FileContent/Models/FileContent.cs
+++ b/src/FileContent/Models/FileContent.cs
@@ -1,3 +1,9 @@
-﻿namespace SimpleRag.FileContent.Models;
+namespace SimpleRag.FileContent.Models;
 
+/// <summary>
+/// Represents the content of a file.
+/// </summary>
+/// <param name="Path">The full path to the file.</param>
+/// <param name="Content">The file content.</param>
+/// <param name="PathWithoutRoot">The path relative to the configured root.</param>
 public record FileContent(string Path, string Content, string PathWithoutRoot);

--- a/src/FileContent/Models/FileContentSource.cs
+++ b/src/FileContent/Models/FileContentSource.cs
@@ -8,13 +8,13 @@ namespace SimpleRag.FileContent.Models;
 public abstract class FileContentSource
 {
     /// <summary>Gets or sets a value indicating whether directories are searched recursively.</summary>
-    public required bool Recursive { get; set; }
+    public required bool Recursive { get; init; }
 
     /// <summary>Gets or sets the root path.</summary>
-    public required string Path { get; set; }
+    public required string Path { get; init; }
 
     /// <summary>Gets or sets patterns for files to ignore.</summary>
-    public required string? FileIgnorePatterns { get; set; }
+    public required string? FileIgnorePatterns { get; init; }
 
     /// <summary>
     /// Determines whether the specified path should be ignored.

--- a/src/FileContent/Models/FileContentSource.cs
+++ b/src/FileContent/Models/FileContentSource.cs
@@ -1,13 +1,24 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 
 namespace SimpleRag.FileContent.Models;
 
+/// <summary>
+/// Base class describing a source of file content.
+/// </summary>
 public abstract class FileContentSource
 {
+    /// <summary>Gets or sets a value indicating whether directories are searched recursively.</summary>
     public required bool Recursive { get; set; }
+
+    /// <summary>Gets or sets the root path.</summary>
     public required string Path { get; set; }
+
+    /// <summary>Gets or sets patterns for files to ignore.</summary>
     public required string? FileIgnorePatterns { get; set; }
 
+    /// <summary>
+    /// Determines whether the specified path should be ignored.
+    /// </summary>
     public bool IgnoreFile(string path)
     {
         if (string.IsNullOrWhiteSpace(FileIgnorePatterns))

--- a/src/FileContent/Models/FileContentSourceGitHub.cs
+++ b/src/FileContent/Models/FileContentSourceGitHub.cs
@@ -6,11 +6,11 @@ namespace SimpleRag.FileContent.Models;
 public class FileContentSourceGitHub : FileContentSource
 {
     /// <summary>Gets or sets the repository owner.</summary>
-    public required string? GitHubOwner { get; set; }
+    public required string? GitHubOwner { get; init; }
 
     /// <summary>Gets or sets the repository name.</summary>
-    public required string? GitHubRepo { get; set; }
+    public required string? GitHubRepo { get; init; }
 
     /// <summary>Gets or sets the timestamp of the last commit processed.</summary>
-    public required DateTimeOffset? GitHubLastCommitTimestamp { get; set; }
+    public required DateTimeOffset? GitHubLastCommitTimestamp { get; init; }
 }

--- a/src/FileContent/Models/FileContentSourceGitHub.cs
+++ b/src/FileContent/Models/FileContentSourceGitHub.cs
@@ -1,8 +1,16 @@
-﻿namespace SimpleRag.FileContent.Models;
+namespace SimpleRag.FileContent.Models;
 
+/// <summary>
+/// Describes a GitHub source for retrieving files.
+/// </summary>
 public class FileContentSourceGitHub : FileContentSource
 {
+    /// <summary>Gets or sets the repository owner.</summary>
     public required string? GitHubOwner { get; set; }
+
+    /// <summary>Gets or sets the repository name.</summary>
     public required string? GitHubRepo { get; set; }
+
+    /// <summary>Gets or sets the timestamp of the last commit processed.</summary>
     public required DateTimeOffset? GitHubLastCommitTimestamp { get; set; }
 }

--- a/src/FileContent/Models/FileContentSourceLocal.cs
+++ b/src/FileContent/Models/FileContentSourceLocal.cs
@@ -1,3 +1,6 @@
-﻿namespace SimpleRag.FileContent.Models;
+namespace SimpleRag.FileContent.Models;
 
+/// <summary>
+/// Represents a local file content source.
+/// </summary>
 public class FileContentSourceLocal : FileContentSource;

--- a/src/Helpers/RetryHelper.cs
+++ b/src/Helpers/RetryHelper.cs
@@ -5,6 +5,12 @@ namespace SimpleRag.Helpers;
 
 internal static class RetryHelper
 {
+    /// <summary>
+    /// Executes the specified function with retry logic.
+    /// </summary>
+    /// <param name="func">The asynchronous function to execute.</param>
+    /// <param name="retries">The number of retries to attempt.</param>
+    /// <param name="waitTime">The delay between retries.</param>
     public static async Task ExecuteWithRetryAsync(Func<Task> func, int retries, TimeSpan waitTime)
     {
         PolicyBuilder assertException = Policy.Handle<Exception>();

--- a/src/Ingestion.cs
+++ b/src/Ingestion.cs
@@ -1,4 +1,5 @@
-﻿using SimpleRag.DataSources.CSharp;
+﻿using JetBrains.Annotations;
+using SimpleRag.DataSources.CSharp;
 using SimpleRag.DataSources.CSharp.Models;
 using SimpleRag.DataSources.Markdown;
 using SimpleRag.DataSources.Markdown.Models;
@@ -10,20 +11,9 @@ namespace SimpleRag;
 /// <summary>
 /// Coordinates ingestion of data sources.
 /// </summary>
-public class Ingestion
+[PublicAPI]
+public class Ingestion(CSharpDataSourceCommand cSharpDataSourceCommand, MarkdownDataSourceCommand markdownDataSourceCommand)
 {
-    private readonly CSharpDataSourceCommand _cSharpDataSourceCommand;
-    private readonly MarkdownDataSourceCommand _markdownDataSourceCommand;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Ingestion"/> class.
-    /// </summary>
-    public Ingestion(CSharpDataSourceCommand cSharpDataSourceCommand, MarkdownDataSourceCommand markdownDataSourceCommand)
-    {
-        _cSharpDataSourceCommand = cSharpDataSourceCommand;
-        _markdownDataSourceCommand = markdownDataSourceCommand;
-    }
-
     /// <summary>
     /// Ingests the provided data sources.
     /// </summary>
@@ -33,8 +23,8 @@ public class Ingestion
         {
             if (onProgressNotification != null)
             {
-                _cSharpDataSourceCommand.NotifyProgress += onProgressNotification;
-                _markdownDataSourceCommand.NotifyProgress += onProgressNotification;
+                cSharpDataSourceCommand.NotifyProgress += onProgressNotification;
+                markdownDataSourceCommand.NotifyProgress += onProgressNotification;
             }
 
             foreach (DataSource source in dataSources)
@@ -43,16 +33,16 @@ public class Ingestion
                 switch (source)
                 {
                     case CSharpDataSourceLocal cSharpDataSourceLocal:
-                        await _cSharpDataSourceCommand.IngestAsync(cSharpDataSourceLocal, options?.CSharpContentFormatBuilder, cancellationToken);
+                        await cSharpDataSourceCommand.IngestAsync(cSharpDataSourceLocal, options?.CSharpContentFormatBuilder, cancellationToken);
                         break;
                     case CSharpDataSourceGitHub cSharpDataSourceGitHub:
-                        await _cSharpDataSourceCommand.IngestAsync(cSharpDataSourceGitHub, options?.CSharpContentFormatBuilder, cancellationToken);
+                        await cSharpDataSourceCommand.IngestAsync(cSharpDataSourceGitHub, options?.CSharpContentFormatBuilder, cancellationToken);
                         break;
                     case MarkdownDataSourceLocal markdownDataSourceLocal:
-                        await _markdownDataSourceCommand.IngestAsync(markdownDataSourceLocal, cancellationToken); //todo support content format builder
+                        await markdownDataSourceCommand.IngestAsync(markdownDataSourceLocal, cancellationToken); //todo support content format builder
                         break;
                     case MarkdownDataSourceGitHub markdownDataSourceGitHub:
-                        await _markdownDataSourceCommand.IngestAsync(markdownDataSourceGitHub, cancellationToken); //todo support content format builder
+                        await markdownDataSourceCommand.IngestAsync(markdownDataSourceGitHub, cancellationToken); //todo support content format builder
                         break;
                 }
             }
@@ -61,8 +51,8 @@ public class Ingestion
         {
             if (onProgressNotification != null)
             {
-                _cSharpDataSourceCommand.NotifyProgress -= onProgressNotification;
-                _markdownDataSourceCommand.NotifyProgress -= onProgressNotification;
+                cSharpDataSourceCommand.NotifyProgress -= onProgressNotification;
+                markdownDataSourceCommand.NotifyProgress -= onProgressNotification;
             }
         }
     }

--- a/src/Ingestion.cs
+++ b/src/Ingestion.cs
@@ -7,17 +7,26 @@ using SimpleRag.Models;
 
 namespace SimpleRag;
 
+/// <summary>
+/// Coordinates ingestion of data sources.
+/// </summary>
 public class Ingestion
 {
     private readonly CSharpDataSourceCommand _cSharpDataSourceCommand;
     private readonly MarkdownDataSourceCommand _markdownDataSourceCommand;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Ingestion"/> class.
+    /// </summary>
     public Ingestion(CSharpDataSourceCommand cSharpDataSourceCommand, MarkdownDataSourceCommand markdownDataSourceCommand)
     {
         _cSharpDataSourceCommand = cSharpDataSourceCommand;
         _markdownDataSourceCommand = markdownDataSourceCommand;
     }
 
+    /// <summary>
+    /// Ingests the provided data sources.
+    /// </summary>
     public async Task IngestAsync(IEnumerable<DataSource> dataSources, IngestionOptions? options = null, Action<ProgressNotification>? onProgressNotification = null, CancellationToken cancellationToken = default)
     {
         try

--- a/src/IngestionOptions.cs
+++ b/src/IngestionOptions.cs
@@ -1,10 +1,12 @@
-﻿using SimpleRag.DataSources.CSharp.Models;
+﻿using JetBrains.Annotations;
+using SimpleRag.DataSources.CSharp.Models;
 
 namespace SimpleRag;
 
 /// <summary>
 /// Options used during ingestion of data sources.
 /// </summary>
+[PublicAPI]
 public class IngestionOptions
 {
     /// <summary>Gets or sets an optional function to build content for C# sources.</summary>

--- a/src/IngestionOptions.cs
+++ b/src/IngestionOptions.cs
@@ -2,7 +2,11 @@
 
 namespace SimpleRag;
 
+/// <summary>
+/// Options used during ingestion of data sources.
+/// </summary>
 public class IngestionOptions
 {
+    /// <summary>Gets or sets an optional function to build content for C# sources.</summary>
     public Func<CSharpChunk, string>? CSharpContentFormatBuilder { get; set; }
 }

--- a/src/Integrations/GitHub/GitHubConnection.cs
+++ b/src/Integrations/GitHub/GitHubConnection.cs
@@ -1,3 +1,7 @@
-﻿namespace SimpleRag.Integrations.GitHub;
+namespace SimpleRag.Integrations.GitHub;
 
+/// <summary>
+/// Configuration for connecting to GitHub.
+/// </summary>
+/// <param name="GitHubToken">The personal access token.</param>
 public record GitHubConnection(string GitHubToken);

--- a/src/Integrations/GitHub/GitHubIntegrationException.cs
+++ b/src/Integrations/GitHub/GitHubIntegrationException.cs
@@ -1,3 +1,6 @@
-﻿namespace SimpleRag.Integrations.GitHub;
+namespace SimpleRag.Integrations.GitHub;
 
+/// <summary>
+/// Exception thrown when GitHub integration fails.
+/// </summary>
 public class GitHubIntegrationException(string message, Exception? innerException = null) : Exception(message, innerException);

--- a/src/Integrations/GitHub/GitHubQuery.cs
+++ b/src/Integrations/GitHub/GitHubQuery.cs
@@ -5,10 +5,10 @@ using ProductHeaderValue = Octokit.ProductHeaderValue;
 
 namespace SimpleRag.Integrations.GitHub;
 
-[UsedImplicitly]
 /// <summary>
 /// Helper methods for interacting with the GitHub API.
 /// </summary>
+[PublicAPI]
 public class GitHubQuery(GitHubConnection connection)
 {
     /// <summary>Gets a value indicating whether a GitHub token is configured.</summary>

--- a/src/Integrations/GitHub/GitHubQuery.cs
+++ b/src/Integrations/GitHub/GitHubQuery.cs
@@ -6,10 +6,18 @@ using ProductHeaderValue = Octokit.ProductHeaderValue;
 namespace SimpleRag.Integrations.GitHub;
 
 [UsedImplicitly]
+/// <summary>
+/// Helper methods for interacting with the GitHub API.
+/// </summary>
 public class GitHubQuery(GitHubConnection connection)
 {
+    /// <summary>Gets a value indicating whether a GitHub token is configured.</summary>
     public bool IsGitHubTokenProvided => !string.IsNullOrWhiteSpace(connection.GitHubToken);
 
+    /// <summary>
+    /// Creates a new authenticated GitHub client.
+    /// </summary>
+    /// <returns>The GitHub client.</returns>
     public GitHubClient GetGitHubClient()
     {
         if (string.IsNullOrWhiteSpace(connection.GitHubToken))
@@ -23,6 +31,9 @@ public class GitHubQuery(GitHubConnection connection)
         };
     }
 
+    /// <summary>
+    /// Gets the tree for the specified commit.
+    /// </summary>
     public async Task<TreeResponse> GetTreeAsync(GitHubClient client, Commit commit, string owner, string repo, bool recursive)
     {
         if (recursive)
@@ -33,6 +44,9 @@ public class GitHubQuery(GitHubConnection connection)
         return await client.Git.Tree.Get(owner, repo, commit.Tree.Sha);
     }
 
+    /// <summary>
+    /// Gets the latest commit of the specified repository.
+    /// </summary>
     public async Task<Commit> GetLatestCommitAsync(GitHubClient client, string owner, string repo)
     {
         Repository repository = await client.Repository.Get(owner, repo);
@@ -43,6 +57,9 @@ public class GitHubQuery(GitHubConnection connection)
         return await client.Git.Commit.Get(owner, repo, reference.Object.Sha);
     }
 
+    /// <summary>
+    /// Retrieves the raw file content from GitHub.
+    /// </summary>
     public async Task<string?> GetFileContentAsync(GitHubClient client, string gitHubOwner, string gitHubRepo, string path)
     {
         byte[]? fileContent = await client.Repository.Content.GetRawContent(gitHubOwner, gitHubRepo, path);

--- a/src/Models/ProgressNotification.cs
+++ b/src/Models/ProgressNotification.cs
@@ -1,3 +1,5 @@
+using JetBrains.Annotations;
+
 namespace SimpleRag.Models;
 
 /// <summary>
@@ -8,6 +10,7 @@ namespace SimpleRag.Models;
 /// <param name="Current">The current progress value.</param>
 /// <param name="Total">The total progress value.</param>
 /// <param name="Details">Optional additional details.</param>
+[PublicAPI]
 public record ProgressNotification(DateTimeOffset Timestamp, string Message, int Current = 0, int Total = 0, string? Details = null)
 {
     /// <summary>Gets or sets optional additional arguments.</summary>

--- a/src/Models/ProgressNotification.cs
+++ b/src/Models/ProgressNotification.cs
@@ -1,9 +1,21 @@
-﻿namespace SimpleRag.Models;
+namespace SimpleRag.Models;
 
+/// <summary>
+/// Represents a progress notification.
+/// </summary>
+/// <param name="Timestamp">The time the notification was created.</param>
+/// <param name="Message">The message describing the progress.</param>
+/// <param name="Current">The current progress value.</param>
+/// <param name="Total">The total progress value.</param>
+/// <param name="Details">Optional additional details.</param>
 public record ProgressNotification(DateTimeOffset Timestamp, string Message, int Current = 0, int Total = 0, string? Details = null)
 {
+    /// <summary>Gets or sets optional additional arguments.</summary>
     public object? Arguments { get; init; }
 
+    /// <summary>
+    /// Gets the formatted message including details.
+    /// </summary>
     public string GetFormattedMessageWithDetails()
     {
         if (Current != 0 && Total != 0)
@@ -16,6 +28,9 @@ public record ProgressNotification(DateTimeOffset Timestamp, string Message, int
         }
     }
 
+    /// <summary>
+    /// Gets the formatted message.
+    /// </summary>
     public string GetFormattedMessage()
     {
         if (Current != 0 && Total != 0)

--- a/src/Models/ProgressNotificationBase.cs
+++ b/src/Models/ProgressNotificationBase.cs
@@ -1,14 +1,24 @@
 namespace SimpleRag.Models;
 
+/// <summary>
+/// Base class providing progress notification support.
+/// </summary>
 public class ProgressNotificationBase
 {
+    /// <summary>Occurs when progress is reported.</summary>
     public event Action<ProgressNotification>? NotifyProgress;
 
+    /// <summary>
+    /// Raises a progress notification.
+    /// </summary>
     protected void OnNotifyProgress(string message, int current = 0, int total = 0, string? details = null)
     {
         NotifyProgress?.Invoke(new ProgressNotification(DateTimeOffset.UtcNow, message, current, total, details));
     }
 
+    /// <summary>
+    /// Raises the specified notification.
+    /// </summary>
     public void OnNotifyProgress(ProgressNotification notification)
     {
         NotifyProgress?.Invoke(notification);

--- a/src/Search.cs
+++ b/src/Search.cs
@@ -4,8 +4,14 @@ using System.Linq.Expressions;
 
 namespace SimpleRag;
 
+/// <summary>
+/// Performs search operations against the vector store.
+/// </summary>
 public class Search(VectorStoreQuery vectorStoreQuery)
 {
+    /// <summary>
+    /// Executes a search using the provided options.
+    /// </summary>
     public async Task<SearchResult> SearchAsync(SearchOptions options)
     {
         return await vectorStoreQuery.SearchAsync(options.SearchQuery, options.NumberOfRecordsBack, options.Filter);

--- a/src/Search.cs
+++ b/src/Search.cs
@@ -1,12 +1,13 @@
-﻿using SimpleRag.VectorStorage;
+﻿using JetBrains.Annotations;
+using SimpleRag.VectorStorage;
 using SimpleRag.VectorStorage.Models;
-using System.Linq.Expressions;
 
 namespace SimpleRag;
 
 /// <summary>
 /// Performs search operations against the vector store.
 /// </summary>
+[PublicAPI]
 public class Search(VectorStoreQuery vectorStoreQuery)
 {
     /// <summary>

--- a/src/SearchOptions.cs
+++ b/src/SearchOptions.cs
@@ -1,11 +1,13 @@
-﻿using System.Linq.Expressions;
+﻿using JetBrains.Annotations;
 using SimpleRag.VectorStorage.Models;
+using System.Linq.Expressions;
 
 namespace SimpleRag;
 
 /// <summary>
 /// Options controlling a search request.
 /// </summary>
+[PublicAPI]
 public class SearchOptions
 {
     /// <summary>Gets or sets the query to search for.</summary>

--- a/src/SearchOptions.cs
+++ b/src/SearchOptions.cs
@@ -3,9 +3,17 @@ using SimpleRag.VectorStorage.Models;
 
 namespace SimpleRag;
 
+/// <summary>
+/// Options controlling a search request.
+/// </summary>
 public class SearchOptions
 {
+    /// <summary>Gets or sets the query to search for.</summary>
     public required string SearchQuery { get; set; }
+
+    /// <summary>Gets or sets the number of records to return.</summary>
     public required int NumberOfRecordsBack { get; set; }
+
+    /// <summary>Gets or sets an optional filter for the search.</summary>
     public Expression<Func<VectorEntity, bool>>? Filter { get; set; }
 }

--- a/src/VectorStorage/Models/SearchResult.cs
+++ b/src/VectorStorage/Models/SearchResult.cs
@@ -9,7 +9,7 @@ namespace SimpleRag.VectorStorage.Models;
 public class SearchResult
 {
     /// <summary>Gets or sets the returned entities.</summary>
-    public required VectorSearchResult<VectorEntity>[] Entities { get; set; }
+    public required VectorSearchResult<VectorEntity>[] Entities { get; init; }
 
     /// <summary>
     /// Formats the result as an XML fragment.

--- a/src/VectorStorage/Models/SearchResult.cs
+++ b/src/VectorStorage/Models/SearchResult.cs
@@ -3,10 +3,17 @@ using Microsoft.Extensions.VectorData;
 
 namespace SimpleRag.VectorStorage.Models;
 
+/// <summary>
+/// Represents the result of a vector search.
+/// </summary>
 public class SearchResult
 {
+    /// <summary>Gets or sets the returned entities.</summary>
     public required VectorSearchResult<VectorEntity>[] Entities { get; set; }
 
+    /// <summary>
+    /// Formats the result as an XML fragment.
+    /// </summary>
     public string GetAsStringResult()
     {
         StringBuilder sb = new();

--- a/src/VectorStorage/Models/VectorEntity.cs
+++ b/src/VectorStorage/Models/VectorEntity.cs
@@ -3,63 +3,88 @@ using Microsoft.Extensions.VectorData;
 
 namespace SimpleRag.VectorStorage.Models;
 
+/// <summary>
+/// Represents a single record stored in the vector store.
+/// </summary>
 public class VectorEntity
 {
     [VectorStoreKey]
+    /// <summary>Gets or sets the unique identifier.</summary>
     public required string Id { get; set; }
 
     [VectorStoreData]
+    /// <summary>Gets or sets the textual content.</summary>
     public required string Content { get; set; }
 
     [VectorStoreData(IsIndexed = true)]
+    /// <summary>Gets or sets the identifier of the source.</summary>
     public required string SourceId { get; set; }
 
     [VectorStoreData(IsIndexed = true)]
+    /// <summary>Gets or sets the kind of the source.</summary>
     public required string SourceKind { get; set; }
 
     [VectorStoreData(IsIndexed = true)]
+    /// <summary>Gets or sets the collection identifier.</summary>
     public required string SourceCollectionId { get; set; }
 
     [VectorStoreData(IsIndexed = true)]
+    /// <summary>Gets or sets the kind of the content.</summary>
     public required string? ContentKind { get; init; }
 
     [VectorStoreData]
+    /// <summary>Gets or sets the content identifier.</summary>
     public required string? ContentId { get; init; }
 
     [VectorStoreData]
+    /// <summary>Gets or sets the parent item of the content.</summary>
     public required string? ContentParent { get; init; }
 
     [VectorStoreData(IsIndexed = true)]
+    /// <summary>Gets or sets the kind of the parent item.</summary>
     public required string? ContentParentKind { get; init; }
 
     [VectorStoreData]
+    /// <summary>Gets or sets the name of the content.</summary>
     public required string? ContentName { get; set; }
 
     [VectorStoreData]
+    /// <summary>Gets or sets content dependencies.</summary>
     public required string? ContentDependencies { get; set; }
 
     [VectorStoreData]
+    /// <summary>Gets or sets the content description.</summary>
     public required string? ContentDescription { get; set; }
 
     [VectorStoreData]
+    /// <summary>Gets or sets references related to the content.</summary>
     public required string? ContentReferences { get; set; }
 
     [VectorStoreData(IsIndexed = true)]
+    /// <summary>Gets or sets the namespace of the content.</summary>
     public required string? ContentNamespace { get; init; }
 
     [VectorStoreData]
+    /// <summary>Gets or sets the original file path of the source.</summary>
     public required string SourcePath { get; init; }
 
     [VectorStoreVector(1536)]
     [UsedImplicitly]
+    /// <summary>Gets the vector embedding for the content.</summary>
     public string Vector => Content;
 
+    /// <summary>
+    /// Generates a unique key for comparing content.
+    /// </summary>
     public string GetContentCompareKey()
     {
         string contentCompareKey = ContentId + SourceKind + ContentKind + ContentName + ContentParent + ContentParentKind + ContentNamespace + ContentDependencies + ContentDescription + ContentReferences + Content;
         return contentCompareKey;
     }
 
+    /// <summary>
+    /// Gets the entity as an XML fragment.
+    /// </summary>
     public string GetAsString()
     {
         return $"<search_result citation=\"todo\">{Content}</search_result>"; //todo: Citation url support

--- a/src/VectorStorage/Models/VectorEntity.cs
+++ b/src/VectorStorage/Models/VectorEntity.cs
@@ -6,71 +6,72 @@ namespace SimpleRag.VectorStorage.Models;
 /// <summary>
 /// Represents a single record stored in the vector store.
 /// </summary>
+[PublicAPI]
 public class VectorEntity
 {
-    [VectorStoreKey]
     /// <summary>Gets or sets the unique identifier.</summary>
+    [VectorStoreKey]
     public required string Id { get; set; }
 
-    [VectorStoreData]
     /// <summary>Gets or sets the textual content.</summary>
+    [VectorStoreData]
     public required string Content { get; set; }
 
-    [VectorStoreData(IsIndexed = true)]
     /// <summary>Gets or sets the identifier of the source.</summary>
+    [VectorStoreData(IsIndexed = true)]
     public required string SourceId { get; set; }
 
-    [VectorStoreData(IsIndexed = true)]
     /// <summary>Gets or sets the kind of the source.</summary>
+    [VectorStoreData(IsIndexed = true)]
     public required string SourceKind { get; set; }
 
-    [VectorStoreData(IsIndexed = true)]
     /// <summary>Gets or sets the collection identifier.</summary>
+    [VectorStoreData(IsIndexed = true)]
     public required string SourceCollectionId { get; set; }
 
-    [VectorStoreData(IsIndexed = true)]
     /// <summary>Gets or sets the kind of the content.</summary>
+    [VectorStoreData(IsIndexed = true)]
     public required string? ContentKind { get; init; }
 
-    [VectorStoreData]
     /// <summary>Gets or sets the content identifier.</summary>
+    [VectorStoreData]
     public required string? ContentId { get; init; }
 
-    [VectorStoreData]
     /// <summary>Gets or sets the parent item of the content.</summary>
+    [VectorStoreData]
     public required string? ContentParent { get; init; }
 
-    [VectorStoreData(IsIndexed = true)]
     /// <summary>Gets or sets the kind of the parent item.</summary>
+    [VectorStoreData(IsIndexed = true)]
     public required string? ContentParentKind { get; init; }
 
-    [VectorStoreData]
     /// <summary>Gets or sets the name of the content.</summary>
+    [VectorStoreData]
     public required string? ContentName { get; set; }
 
-    [VectorStoreData]
     /// <summary>Gets or sets content dependencies.</summary>
+    [VectorStoreData]
     public required string? ContentDependencies { get; set; }
 
-    [VectorStoreData]
     /// <summary>Gets or sets the content description.</summary>
+    [VectorStoreData]
     public required string? ContentDescription { get; set; }
 
-    [VectorStoreData]
     /// <summary>Gets or sets references related to the content.</summary>
+    [VectorStoreData]
     public required string? ContentReferences { get; set; }
 
-    [VectorStoreData(IsIndexed = true)]
     /// <summary>Gets or sets the namespace of the content.</summary>
+    [VectorStoreData(IsIndexed = true)]
     public required string? ContentNamespace { get; init; }
 
-    [VectorStoreData]
     /// <summary>Gets or sets the original file path of the source.</summary>
+    [VectorStoreData]
     public required string SourcePath { get; init; }
 
+    /// <summary>Gets the vector embedding for the content.</summary>
     [VectorStoreVector(1536)]
     [UsedImplicitly]
-    /// <summary>Gets the vector embedding for the content.</summary>
     public string Vector => Content;
 
     /// <summary>

--- a/src/VectorStorage/VectorStoreCommand.cs
+++ b/src/VectorStorage/VectorStoreCommand.cs
@@ -5,10 +5,10 @@ using SimpleRag.VectorStorage.Models;
 
 namespace SimpleRag.VectorStorage;
 
-[UsedImplicitly]
 /// <summary>
 /// Provides commands for modifying the vector store.
 /// </summary>
+[PublicAPI]
 public class VectorStoreCommand(VectorStore vectorStore, VectorStoreConfiguration vectorStoreConfiguration)
 {
     private bool _creationEnsured;

--- a/src/VectorStorage/VectorStoreCommand.cs
+++ b/src/VectorStorage/VectorStoreCommand.cs
@@ -6,6 +6,9 @@ using SimpleRag.VectorStorage.Models;
 namespace SimpleRag.VectorStorage;
 
 [UsedImplicitly]
+/// <summary>
+/// Provides commands for modifying the vector store.
+/// </summary>
 public class VectorStoreCommand(VectorStore vectorStore, VectorStoreConfiguration vectorStoreConfiguration)
 {
     private bool _creationEnsured;
@@ -23,6 +26,9 @@ public class VectorStoreCommand(VectorStore vectorStore, VectorStoreConfiguratio
         return collection;
     }
 
+    /// <summary>
+    /// Inserts or updates the specified entity.
+    /// </summary>
     public async Task UpsertAsync(VectorEntity entity, CancellationToken cancellationToken = default)
     {
         try
@@ -54,6 +60,9 @@ public class VectorStoreCommand(VectorStore vectorStore, VectorStoreConfiguratio
         }
     }
 
+    /// <summary>
+    /// Deletes all entities matching the filter.
+    /// </summary>
     public async Task DeleteAsync(Expression<Func<VectorEntity, bool>> filter, CancellationToken cancellationToken = default)
     {
         List<string> keysToDelete = [];
@@ -69,6 +78,9 @@ public class VectorStoreCommand(VectorStore vectorStore, VectorStoreConfiguratio
         await DeleteAsync(keysToDelete, cancellationToken);
     }
 
+    /// <summary>
+    /// Deletes the entities with the specified keys.
+    /// </summary>
     public async Task DeleteAsync(IEnumerable<string> keysToDelete, CancellationToken cancellationToken = default)
     {
         var collection = await GetCollectionAndEnsureItExist(cancellationToken);

--- a/src/VectorStorage/VectorStoreConfiguration.cs
+++ b/src/VectorStorage/VectorStoreConfiguration.cs
@@ -1,3 +1,8 @@
-﻿namespace SimpleRag.VectorStorage;
+namespace SimpleRag.VectorStorage;
 
+/// <summary>
+/// Configuration for connecting to the vector store.
+/// </summary>
+/// <param name="CollectionName">The name of the collection.</param>
+/// <param name="MaxRecordSearch">The optional maximum number of records to search.</param>
 public record VectorStoreConfiguration(string CollectionName, int? MaxRecordSearch = null);

--- a/src/VectorStorage/VectorStoreQuery.cs
+++ b/src/VectorStorage/VectorStoreQuery.cs
@@ -4,6 +4,9 @@ using SimpleRag.VectorStorage.Models;
 
 namespace SimpleRag.VectorStorage;
 
+/// <summary>
+/// Provides query operations against the vector store.
+/// </summary>
 public class VectorStoreQuery(VectorStore vectorStore, VectorStoreConfiguration vectorStoreConfiguration)
 {
     private bool _creationEnsured;
@@ -22,6 +25,9 @@ public class VectorStoreQuery(VectorStore vectorStore, VectorStoreConfiguration 
     }
 
 
+    /// <summary>
+    /// Searches the vector store.
+    /// </summary>
     public async Task<SearchResult> SearchAsync(string searchQuery, int numberOfRecordsBack, Expression<Func<VectorEntity, bool>>? filter, CancellationToken cancellationToken = default)
     {
         VectorStoreCollection<string, VectorEntity> collection = await GetCollectionAndEnsureItExist(cancellationToken);
@@ -52,6 +58,9 @@ public class VectorStoreQuery(VectorStore vectorStore, VectorStoreConfiguration 
         };
     }
 
+    /// <summary>
+    /// Retrieves existing records matching the filter.
+    /// </summary>
     public async Task<VectorEntity[]> GetExistingAsync(Expression<Func<VectorEntity, bool>>? filter = null, CancellationToken cancellationToken = default)
     {
         List<VectorEntity> result = [];


### PR DESCRIPTION
## Summary
- document public options in `SearchOptions`
- describe vector store configuration and file content sources
- clarify behaviors in various core classes
- add summaries throughout public types and methods

## Testing
- `dotnet build --no-restore` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6870021f2c3c8325b0107e36e0ba9916